### PR TITLE
Introduce save scheme v3: store SHA-256 of read token

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -92,9 +92,13 @@ func apiSaveSecret(r *http.Request) (responseCode int, response []byte) {
 
 	r.Body = http.MaxBytesReader(nil, r.Body, maxSaveSecretBodyBytes)
 
+	// Unknown fields are ignored on purpose (encoding/json's default), so a
+	// later addition such as manageTokenHash needs no version bump here.
 	var payload struct {
 		SecretMessage string `json:"secretMessage"`
 		HashedKey     string `json:"hashedKey"`
+		ReadTokenHash string `json:"readTokenHash"`
+		Version       int    `json:"v"`
 		Duration      int    `json:"duration"`
 		Views         int    `json:"views"`
 	}
@@ -103,12 +107,14 @@ func apiSaveSecret(r *http.Request) (responseCode int, response []byte) {
 	if dec.More() {
 		err := dec.Decode(&payload)
 		if err == nil {
-			if len(payload.SecretMessage) > 0 && len(payload.HashedKey) > 0 {
+			readTokenHash, scheme, schemeOK := resolveSaveScheme(payload.HashedKey, payload.ReadTokenHash, payload.Version)
+			if len(payload.SecretMessage) > 0 && schemeOK {
 
 				newMessage := StoredMessage{
 					Encrypted: true,
 					Message:   payload.SecretMessage,
-					HashedKey: payload.HashedKey,
+					HashedKey: readTokenHash,
+					Version:   scheme,
 				}
 				views := min(max(payload.Views, 1), maxViews)
 				// Single view stays 0 so default records match the legacy shape.
@@ -121,7 +127,7 @@ func apiSaveSecret(r *http.Request) (responseCode int, response []byte) {
 				}
 
 				if DEBUG {
-					log.Printf("payload -> storage: %v, HashedKey: %v, Duration: %v\n", payload.SecretMessage, payload.HashedKey, payload.Duration)
+					log.Printf("payload -> storage: %v, stored key: %v, scheme: %v, Duration: %v\n", payload.SecretMessage, readTokenHash, scheme, payload.Duration)
 				}
 				valueToStore, _ := json.Marshal(newMessage)
 				storeKey, err := saveToStorageFunc(valueToStore, time.Duration(payload.Duration)*time.Second, views)
@@ -295,6 +301,8 @@ func apiSaveSecretFile(r *http.Request) (responseCode int, response []byte) {
 	}()
 
 	hashedKey := r.FormValue("hashedKey")
+	submittedHash := r.FormValue("readTokenHash")
+	schemeVersion, _ := strconv.Atoi(r.FormValue("v"))
 	durationStr := r.FormValue("duration")
 	viewsStr := r.FormValue("views")
 
@@ -306,7 +314,8 @@ func apiSaveSecretFile(r *http.Request) (responseCode int, response []byte) {
 	}
 	defer file.Close()
 
-	if hashedKey == "" {
+	readTokenHash, scheme, schemeOK := resolveSaveScheme(hashedKey, submittedHash, schemeVersion)
+	if !schemeOK {
 		response, _ = json.Marshal(jResponse)
 		return
 	}
@@ -324,7 +333,7 @@ func apiSaveSecretFile(r *http.Request) (responseCode int, response []byte) {
 	}
 
 	if DEBUG {
-		log.Printf("payload -> file storage: %v bytes, HashedKey: %v, Duration: %v\n", fileHeader.Size, hashedKey, duration)
+		log.Printf("payload -> file storage: %v bytes, stored key: %v, scheme: %v, Duration: %v\n", fileHeader.Size, readTokenHash, scheme, duration)
 	}
 
 	// Ensure storage dir exists
@@ -388,7 +397,8 @@ func apiSaveSecretFile(r *http.Request) (responseCode int, response []byte) {
 		record := StoredFile{
 			Encrypted: true,
 			FileUri:   filePath,
-			HashedKey: hashedKey,
+			HashedKey: readTokenHash,
+			Version:   scheme,
 		}
 		if views != 1 {
 			record.Views = views

--- a/backend/handlers_test.go
+++ b/backend/handlers_test.go
@@ -847,3 +847,115 @@ func TestAPIGetFileRejectsBadPayload(t *testing.T) {
 		t.Fatal("reserveFileDownloadFunc should not be called for bad payload")
 	}
 }
+
+// A real SHA-256, in the form a client actually uploads. A placeholder here
+// would let a missing shape check pass unnoticed.
+const validReadTokenHash = "ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb"
+
+// --- v3 save wiring ----------------------------------------------------------
+//
+// resolveSaveScheme is unit-tested in isolation, which proves nothing about the
+// handlers persisting the version they resolved. Dropping `Version: scheme`
+// from either struct literal keeps every other test green and loses every v3
+// secret. These are that guard.
+
+func TestAPISaveSecretPersistsV3Scheme(t *testing.T) {
+	restoreHandlerHooks(t)
+
+	var stored StoredMessage
+	saveToStorageFunc = func(value interface{}, duration time.Duration, views int) (string, error) {
+		raw, _ := value.([]byte)
+		if err := json.Unmarshal(raw, &stored); err != nil {
+			t.Fatalf("stored payload is not StoredMessage JSON: %v", err)
+		}
+		return "msg-v3", nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/saveSecret",
+		strings.NewReader(`{"secretMessage":"ciphertext","readTokenHash":"ffe054fe7ae0cb6dc65c3af9b61d5209f439851db43d0ba5997337df154668eb","v":3,"duration":60}`))
+	responseCode, response := apiSaveSecret(req)
+
+	if responseCode != http.StatusOK || !strings.Contains(string(response), `"status":"ok"`) {
+		t.Fatalf("apiSaveSecret() = (%d, %s), want ok", responseCode, response)
+	}
+	if stored.Version != secretSchemeV3 {
+		t.Fatalf("stored Version = %d, want %d — a v3 upload was recorded as v2 and is now unreadable",
+			stored.Version, secretSchemeV3)
+	}
+	if stored.HashedKey != validReadTokenHash {
+		t.Fatalf("stored HashedKey = %q, want the uploaded hash", stored.HashedKey)
+	}
+}
+
+func TestAPISaveSecretLegacyUploadStaysScheme0(t *testing.T) {
+	restoreHandlerHooks(t)
+
+	var stored StoredMessage
+	saveToStorageFunc = func(value interface{}, duration time.Duration, views int) (string, error) {
+		raw, _ := value.([]byte)
+		_ = json.Unmarshal(raw, &stored)
+		return "msg-v2", nil
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/api/saveSecret",
+		strings.NewReader(`{"secretMessage":"ciphertext","hashedKey":"thetoken","duration":60}`))
+	if code, _ := apiSaveSecret(req); code != http.StatusOK {
+		t.Fatalf("legacy save rejected: code = %d", code)
+	}
+	if stored.Version != 0 || stored.HashedKey != "thetoken" {
+		t.Fatalf("legacy record = %#v, want the token stored under scheme 0", stored)
+	}
+}
+
+func TestAPISaveSecretFilePersistsV3Scheme(t *testing.T) {
+	restoreHandlerHooks(t)
+
+	originalDir := fileStorageDir
+	fileStorageDir = t.TempDir()
+	t.Cleanup(func() { fileStorageDir = originalDir })
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	fileWriter, err := writer.CreateFormFile("file", "secret.enc")
+	if err != nil {
+		t.Fatalf("CreateFormFile error: %v", err)
+	}
+	if _, err := fileWriter.Write([]byte("encrypted file bytes")); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if err := writer.WriteField("readTokenHash", validReadTokenHash); err != nil {
+		t.Fatalf("WriteField readTokenHash error: %v", err)
+	}
+	if err := writer.WriteField("v", "3"); err != nil {
+		t.Fatalf("WriteField v error: %v", err)
+	}
+	if err := writer.WriteField("duration", "120"); err != nil {
+		t.Fatalf("WriteField duration error: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("Close writer error: %v", err)
+	}
+
+	var record StoredFile
+	setFileRecordFunc = func(storeKey string, value interface{}, duration time.Duration) (bool, error) {
+		raw, _ := value.([]byte)
+		if err := json.Unmarshal(raw, &record); err != nil {
+			t.Fatalf("file record JSON error: %v", err)
+		}
+		return true, nil
+	}
+	incrementStoredFileCountersFunc = func(views int, now time.Time) error { return nil }
+
+	req := httptest.NewRequest(http.MethodPost, "/api/saveFile", bytes.NewReader(body.Bytes()))
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	if code, _ := apiSaveSecretFile(req); code != http.StatusOK {
+		t.Fatalf("v3 file save rejected: code = %d", code)
+	}
+	if record.Version != secretSchemeV3 {
+		t.Fatalf("stored file Version = %d, want %d — v3 upload recorded as v2, file now undownloadable",
+			record.Version, secretSchemeV3)
+	}
+	if record.HashedKey != validReadTokenHash {
+		t.Fatalf("stored file HashedKey = %q, want the uploaded hash", record.HashedKey)
+	}
+}

--- a/backend/stats.go
+++ b/backend/stats.go
@@ -58,6 +58,8 @@ var statPageNames = [statPageCount]string{
 type pageHitSnapshot [statPageCount]int64
 
 type StatsSnapshot struct {
+	APIVersion           int              `json:"apiVersion"`
+	SaveSchemes          []int            `json:"saveSchemes"`
 	OverallStoredSecrets int64            `json:"overallStoredSecrets"`
 	OverallStoredFiles   int64            `json:"overallStoredFiles"`
 	PendingPageHits      map[string]int64 `json:"pendingPageHits"`
@@ -120,6 +122,8 @@ func (s *StatsManager) GetSnapshot() StatsSnapshot {
 	s.mu.Unlock()
 
 	snapshot := StatsSnapshot{
+		APIVersion:           apiVersion,
+		SaveSchemes:          supportedSaveSchemes(),
 		OverallStoredSecrets: s.GetOverallStoredSecrets(),
 		OverallStoredFiles:   s.GetOverallStoredFiles(),
 		PendingPageHits:      make(map[string]int64, statPageCount),

--- a/backend/stats_test.go
+++ b/backend/stats_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -366,5 +368,48 @@ func TestAPIStatSnapshotReturnsBufferedStats(t *testing.T) {
 	}
 	if !strings.Contains(body, `"password":2`) {
 		t.Fatalf("snapshot body = %s, missing password count", body)
+	}
+}
+
+// The scheme list on /api/ss is only useful if it cannot drift from what the
+// server actually accepts — an operator reading it is deciding whether a
+// rollback is safe, so a stale list is worse than none.
+func TestStatSnapshotAdvertisesTheSchemesItAccepts(t *testing.T) {
+	advertised := supportedSaveSchemes()
+	if len(advertised) == 0 {
+		t.Fatal("no save schemes advertised")
+	}
+
+	token := strings.Repeat("a", hashedKeyHexLen)
+	sum := sha256.Sum256([]byte(token))
+	hash := hex.EncodeToString(sum[:])
+
+	accepts := func(scheme int) bool {
+		if scheme == 0 {
+			_, _, ok := resolveSaveScheme(token, "", 0)
+			return ok
+		}
+		_, _, ok := resolveSaveScheme("", hash, scheme)
+		return ok
+	}
+
+	for _, scheme := range advertised {
+		if !accepts(scheme) {
+			t.Fatalf("scheme %d is advertised but resolveSaveScheme rejects it", scheme)
+		}
+	}
+
+	// And nothing outside the list is quietly accepted.
+	for _, scheme := range []int{1, 2, 4, 99} {
+		if accepts(scheme) {
+			t.Fatalf("scheme %d is accepted but not advertised", scheme)
+		}
+	}
+}
+
+func TestStatSnapshotCarriesAPIVersion(t *testing.T) {
+	snapshot := NewStatsManager().GetSnapshot()
+	if snapshot.APIVersion != apiVersion {
+		t.Fatalf("snapshot APIVersion = %d, want %d", snapshot.APIVersion, apiVersion)
 	}
 }

--- a/backend/storage.go
+++ b/backend/storage.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/subtle"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"log"
@@ -23,6 +25,38 @@ const redisTimeout = time.Second * 10
 const fileJanitorInterval = 2 * time.Hour
 
 const hashedKeyHexLen = 64
+
+// secretSchemeV3 records store SHA-256(readToken) rather than the token, so the
+// server holds nothing that can read a secret. Version 0 means v2 (the token
+// itself), which is what pre-existing records unmarshal to.
+const secretSchemeV3 = 3
+
+// tokenMatchesStored reports whether the token a reader presented matches what
+// the record holds. v2 records store the token itself; v3 records store its
+// SHA-256.
+//
+// The hash is taken over the token's HEX STRING as transmitted, not the 32 raw
+// bytes it encodes. protocol.mjs must hash the same representation: this is the
+// one place client and server can disagree silently, and every v3 secret would
+// become unreadable. Both stored forms are 64 hex characters, so
+// isValidHashedKey validates either.
+func tokenMatchesStored(stored string, version int, presented string) bool {
+	var candidate string
+	switch version {
+	case 0:
+		candidate = presented
+	case secretSchemeV3:
+		sum := sha256.Sum256([]byte(presented))
+		candidate = hex.EncodeToString(sum[:])
+	default:
+		// Written by a newer binary — a rolling deploy, or a rollback. No safe
+		// guess exists, so refuse.
+		return false
+	}
+
+	return subtle.ConstantTimeCompare([]byte(stored), []byte(candidate)) == 1
+}
+
 const consumeMessageRetryWindow = 500 * time.Millisecond
 const consumeMessageRetryBaseDelay = 5 * time.Millisecond
 const consumeMessageRetryMaxDelay = 40 * time.Millisecond
@@ -210,7 +244,7 @@ func reserveFileDownloadWithClient(client *redis.Client, key string, hashedKey s
 			if unmarshalErr := json.Unmarshal([]byte(value), &current); unmarshalErr != nil {
 				return unmarshalErr
 			}
-			if subtle.ConstantTimeCompare([]byte(current.HashedKey), []byte(hashedKey)) != 1 {
+			if !tokenMatchesStored(current.HashedKey, current.Version, hashedKey) {
 				status = "wrong key"
 				return nil
 			}
@@ -411,7 +445,7 @@ func consumeMessageFromStorageWithClient(client *redis.Client, key string, hashe
 				return unmarshalErr
 			}
 
-			if subtle.ConstantTimeCompare([]byte(current.HashedKey), []byte(hashedKey)) != 1 {
+			if !tokenMatchesStored(current.HashedKey, current.Version, hashedKey) {
 				status = "wrong key"
 				return nil
 			}

--- a/backend/storage_test.go
+++ b/backend/storage_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
@@ -615,5 +617,235 @@ func TestSaveToStorageCountsStoredSecretOnce(t *testing.T) {
 	}
 	if len(gotViews) != 1 || gotViews[0] != 5 {
 		t.Fatalf("recorded views = %#v, want [5]", gotViews)
+	}
+}
+
+// --- v3 scheme: SHA-256(readToken) at rest -----------------------------------
+//
+// The migration rests on one claim: a client that knows nothing about v3 can
+// still read a v3 record, because the read request is byte-identical in both
+// schemes. These tests exist to keep that claim true.
+
+func v3StoredHash(readToken string) string {
+	sum := sha256.Sum256([]byte(readToken))
+	return hex.EncodeToString(sum[:])
+}
+
+func TestConsumeMessageV3RecordAcceptsUnchangedReadToken(t *testing.T) {
+	client := startTestRedis(t)
+	const id = "v3-old-client"
+	readToken := strings.Repeat("a", hashedKeyHexLen)
+	storeTestMessage(t, client, id, StoredMessage{
+		Encrypted: true,
+		Message:   "ciphertext",
+		HashedKey: v3StoredHash(readToken),
+		Version:   secretSchemeV3,
+	}, time.Minute)
+
+	// Exactly what a pre-v3 client sends: the token itself, no version.
+	stored, _, _, status, err := consumeMessageFromStorageWithClient(client, id, readToken)
+	if err != nil {
+		t.Fatalf("consumeMessageFromStorageWithClient() error = %v", err)
+	}
+	if status != "ok" || stored.Message != "ciphertext" {
+		t.Fatalf("v3 record rejected an unmodified client: status = %q, message = %q", status, stored.Message)
+	}
+}
+
+func TestConsumeMessageV3RecordRejectsTheStoredHash(t *testing.T) {
+	client := startTestRedis(t)
+	const id = "v3-hash-replay"
+	readToken := strings.Repeat("a", hashedKeyHexLen)
+	storedHash := v3StoredHash(readToken)
+	storeTestMessage(t, client, id, StoredMessage{
+		Encrypted: true,
+		Message:   "ciphertext",
+		HashedKey: storedHash,
+		Version:   secretSchemeV3,
+	}, time.Minute)
+
+	// Anyone holding the database (or an intercepted save request) has the hash
+	// but not its preimage. Presenting the hash must not read the secret — this
+	// is the entire point of the scheme.
+	_, _, _, status, err := consumeMessageFromStorageWithClient(client, id, storedHash)
+	if err != nil {
+		t.Fatalf("consumeMessageFromStorageWithClient() error = %v", err)
+	}
+	if status != "wrong key" {
+		t.Fatalf("stored hash was accepted as a read token: status = %q, want \"wrong key\"", status)
+	}
+	if err := client.Get(getStoreKey(id)).Err(); err == redis.Nil {
+		t.Fatal("failed read consumed the record")
+	}
+}
+
+func TestResolveSaveSchemeRejectsMismatchedVersionAndField(t *testing.T) {
+	token := strings.Repeat("a", hashedKeyHexLen)
+	hash := v3StoredHash(token)
+
+	cases := []struct {
+		name       string
+		legacy     string
+		hash       string
+		version    int
+		wantStored string
+		wantScheme int
+		wantOK     bool
+	}{
+		{"legacy client", token, "", 0, token, 0, true},
+		{"v3 client", "", hash, secretSchemeV3, hash, secretSchemeV3, true},
+		{"v3 claimed without hash", token, "", secretSchemeV3, "", 0, false},
+		{"hash sent without version", "", hash, 0, "", 0, false},
+		{"nothing at all", "", "", 0, "", 0, false},
+		// Unknown schemes are refused, never reinterpreted as the newest known.
+		{"future version with hash", "", hash, 4, "", 0, false},
+		{"future version with token", token, "", 4, "", 0, false},
+		{"unknown version between", token, hash, 2, "", 0, false},
+		// A v3 upload must not carry the read token at all.
+		{"v3 with the token alongside the hash", token, hash, secretSchemeV3, "", 0, false},
+		// A malformed hash can never match at read time.
+		{"v3 hash too short", "", "abc", secretSchemeV3, "", 0, false},
+		{"v3 hash not hex", "", strings.Repeat("z", hashedKeyHexLen), secretSchemeV3, "", 0, false},
+		{"v3 hash uppercase hex", "", strings.ToUpper(hash), secretSchemeV3, "", 0, false},
+		{"v3 hash one char long", "", hash + "a", secretSchemeV3, "", 0, false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			stored, scheme, ok := resolveSaveScheme(tc.legacy, tc.hash, tc.version)
+			if stored != tc.wantStored || scheme != tc.wantScheme || ok != tc.wantOK {
+				t.Fatalf("resolveSaveScheme() = (%q, %d, %v), want (%q, %d, %v)",
+					stored, scheme, ok, tc.wantStored, tc.wantScheme, tc.wantOK)
+			}
+		})
+	}
+}
+
+// TestInteropVectorFromProtocolMjs pins the one thing the two languages must
+// agree on: what gets hashed. The vector below was produced by
+// frontend/src/lib/protocol.mjs -> encryptSecretMessage('K7bQ2mXp9vRt4nLw8zYc').
+//
+// Regenerate it with:
+//
+//	node --input-type=module -e "import {encryptSecretMessage} from
+//	  './frontend/src/lib/protocol.mjs';
+//	  const {hashedKey, readTokenHash} =
+//	    await encryptSecretMessage('x', 'K7bQ2mXp9vRt4nLw8zYc');
+//	  console.log(hashedKey, readTokenHash)"
+//
+// If this fails, one side changed what it digests — the hex string or the raw
+// bytes it encodes — and every v3 secret would become unreadable in production
+// with no error logged anywhere.
+func TestInteropVectorFromProtocolMjs(t *testing.T) {
+	const readToken = "5e6c13f429c1e6eb0c69bc2e67e98e7aa18db0a4bac73f943858694ac3fbe957"
+	const readTokenHash = "3bfecb0a1d1bc37a3e70eb843af6578ee1fa34c19fd059a89dfbdda4523bf396"
+
+	if !tokenMatchesStored(readTokenHash, secretSchemeV3, readToken) {
+		t.Fatal("Go rejected the hash produced by protocol.mjs: client and server disagree on what is hashed")
+	}
+	if tokenMatchesStored(readTokenHash, 0, readToken) {
+		t.Fatal("v2 comparison accepted a v3 hash")
+	}
+}
+
+// The file path carries the same scheme, and its reservation logic is the most
+// delicate code here, so the compatibility claim is proved for it too.
+
+func TestReserveFileDownloadV3RecordAcceptsUnchangedReadToken(t *testing.T) {
+	client := startTestRedis(t)
+	filePath := filepath.Join(t.TempDir(), "v3.enc")
+	if err := os.WriteFile(filePath, []byte("ciphertext"), 0o600); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+	readToken := strings.Repeat("e", hashedKeyHexLen)
+	storeTestFile(t, client, "v3-file", StoredFile{
+		Encrypted: true,
+		FileUri:   filePath,
+		HashedKey: v3StoredHash(readToken),
+		Version:   secretSchemeV3,
+	}, time.Minute)
+
+	// A pre-v3 client downloads a v3 file link: the token, unchanged.
+	reservation, status, err := reserveFileDownloadWithClient(client, "v3-file", readToken)
+	if err != nil {
+		t.Fatalf("reserveFileDownloadWithClient() error = %v", err)
+	}
+	if status != "ok" || reservation.File == nil {
+		t.Fatalf("v3 file record rejected an unmodified client: (%+v, %q)", reservation, status)
+	}
+	reservation.File.Close()
+}
+
+func TestReserveFileDownloadV3RecordRejectsTheStoredHash(t *testing.T) {
+	client := startTestRedis(t)
+	filePath := filepath.Join(t.TempDir(), "v3-replay.enc")
+	if err := os.WriteFile(filePath, []byte("ciphertext"), 0o600); err != nil {
+		t.Fatalf("write test file: %v", err)
+	}
+	readToken := strings.Repeat("e", hashedKeyHexLen)
+	storedHash := v3StoredHash(readToken)
+	storeTestFile(t, client, "v3-replay", StoredFile{
+		Encrypted: true,
+		FileUri:   filePath,
+		HashedKey: storedHash,
+		Version:   secretSchemeV3,
+	}, time.Minute)
+
+	// Whoever holds the database holds the hash but not its preimage.
+	_, status, err := reserveFileDownloadWithClient(client, "v3-replay", storedHash)
+	if err != nil {
+		t.Fatalf("reserveFileDownloadWithClient() error = %v", err)
+	}
+	if status != "wrong key" {
+		t.Fatalf("stored hash was accepted for a file download: %q, want \"wrong key\"", status)
+	}
+	if err := client.Get(getFileStoreKey("v3-replay")).Err(); err == redis.Nil {
+		t.Fatal("failed download consumed the record")
+	}
+}
+
+func TestConsumeMessageV3MultiViewDecrementsWithoutRehashConfusion(t *testing.T) {
+	client := startTestRedis(t)
+	readToken := strings.Repeat("d", hashedKeyHexLen)
+	storeTestMessage(t, client, "v3-multi", StoredMessage{
+		Encrypted: true,
+		Message:   "ciphertext",
+		HashedKey: v3StoredHash(readToken),
+		Views:     3,
+		Version:   secretSchemeV3,
+	}, time.Minute)
+
+	// Each read must re-hash the presented token, not compare it to the value
+	// left over from the previous pass.
+	for want := 2; want >= 0; want-- {
+		_, viewsLeft, _, status, err := consumeMessageFromStorageWithClient(client, "v3-multi", readToken)
+		if err != nil {
+			t.Fatalf("read error: %v", err)
+		}
+		if status != "ok" || viewsLeft != want {
+			t.Fatalf("read: status = %q, viewsLeft = %d, want ok/%d", status, viewsLeft, want)
+		}
+	}
+	if err := client.Get(getStoreKey("v3-multi")).Err(); err != redis.Nil {
+		t.Fatal("record survived its last view")
+	}
+}
+
+func TestTokenMatchesStoredRefusesUnknownScheme(t *testing.T) {
+	token := strings.Repeat("a", hashedKeyHexLen)
+
+	if !tokenMatchesStored(token, 0, token) {
+		t.Fatal("v2 record rejected its own token")
+	}
+	if !tokenMatchesStored(v3StoredHash(token), secretSchemeV3, token) {
+		t.Fatal("v3 record rejected its own token")
+	}
+	// A record written by a newer binary. Neither comparison is known to apply,
+	// so both must fail closed rather than guess.
+	if tokenMatchesStored(token, 4, token) {
+		t.Fatal("unknown scheme fell through to the v2 comparison")
+	}
+	if tokenMatchesStored(v3StoredHash(token), 4, token) {
+		t.Fatal("unknown scheme fell through to the v3 comparison")
 	}
 }

--- a/frontend/src/pages/ss/index.astro
+++ b/frontend/src/pages/ss/index.astro
@@ -31,6 +31,14 @@ const description = `Current in-memory stats snapshot for ${siteHost}.`;
                 <span class="stats-label">Buffered page hits</span>
                 <strong class="stats-value" data-stat-pending>0</strong>
             </section>
+            <section class="stats-card">
+                <span class="stats-label">API version</span>
+                <strong class="stats-value" data-stat-apiversion>&mdash;</strong>
+            </section>
+            <section class="stats-card">
+                <span class="stats-label">Save schemes</span>
+                <strong class="stats-value" data-stat-schemes>&mdash;</strong>
+            </section>
         </div>
 
         <section class="stats-table-card">


### PR DESCRIPTION
Introduce save scheme v3: store SHA-256 of the read token
The server used to store the read token itself, so anything that saw a save
request or the database could fetch a secret and — the real problem —
consume the link before the recipient got it. v3 uploads only the token's
SHA-256. The server still verifies a reader by hashing what they present,
but never holds a value that reads or destroys a secret.
  fullSecretKey              in the URL fragment, never transmitted
    ├── encryptionKey        HKDF(root, info="encrypt"), client-side only
    └── readToken            HKDF(root, info="auth"), sent at READ
          └── readTokenHash  SHA-256(readToken), sent at SAVE, stored
                     v2                    v3
  sends at SAVE      the token             SHA-256(token)
  server stores      the token             the hash
  sends at READ      the token             the token  (identical)
  server compares    stored == presented   stored == SHA-256(presented)
Integrity and availability, not confidentiality: the fragment key was
always required to decrypt and still is. The info string stays "auth" —
historical, and frozen, since changing it breaks outstanding links.
Because reads are byte-identical, a client predating v3 opens a v3 link
unchanged: no read-side migration, no fragment marker, no cutover date. No
data migration either — absent `v` unmarshals to zero, which *is* v2. Old
clients keep writing v2 and keep working.


this PR is for 